### PR TITLE
Added `h` flag to hide snippets from inline suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 *.vsix
+.vscode

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ flags are the following:
 
 - `m`: Math mode
 
+- `h`: Hidden snippet - *Requires `A` flag*. By default, all non-regex snippets will be listed by 
+  the inline suggestions. This `h` flag hides the snippet from the inline suggestions.
+
 \*: This flag will only affect snippets which have non-regex triggers.
 
 ### Snippet body

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "hsnips",
+    "name": "HyperSnipsV2",
     "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "hsnips",
+            "name": "HyperSnipsV2",
             "version": "1.0.1",
             "license": "MIT",
             "devDependencies": {

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -142,7 +142,7 @@ export function getCompletions(
     let completion = new CompletionInfo(snippet, label, snippetRange, matchGroups);
     if (snippet.automatic && snippetMatches) {
       return completion;
-    } else if (prefixMatches) {
+    } else if (prefixMatches && !snippet.hidden) {
       completions.push(completion);
     }
   }

--- a/src/hsnippet.ts
+++ b/src/hsnippet.ts
@@ -22,6 +22,7 @@ export class HSnippet {
   wordboundary = false;
   beginningofline = false;
   math = false;
+  hidden = false;
 
   constructor(header: IHSnippetHeader, generator: GeneratorFunction, placeholders: number) {
     this.description = header.description;
@@ -42,6 +43,7 @@ export class HSnippet {
     if (header.flags.includes('w')) this.wordboundary = true;
     if (header.flags.includes('b')) this.beginningofline = true;
     if (header.flags.includes('m')) this.math = true;
+    if (header.flags.includes('h')) this.hidden = true;
   }
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import { HSnippet, IHSnippetHeader } from './hsnippet';
 
 const CODE_DELIMITER = '``';
-const HEADER_REGEXP = /^snippet ?(?:`([^`]+)`|(\S+))?(?: "([^"]+)")?(?: ([AMiwbm]*))?/;
+const HEADER_REGEXP = /^snippet ?(?:`([^`]+)`|(\S+))?(?: "([^"]+)")?(?: ([AMiwbmh]*))?/;
 
 function parseSnippetHeader(header: string): IHSnippetHeader {
   let match = HEADER_REGEXP.exec(header);

--- a/syntaxes/hsnips.tmLanguage.json
+++ b/syntaxes/hsnips.tmLanguage.json
@@ -3,7 +3,7 @@
   "name": "comment",
   "patterns": [
     {
-      "begin": "^(snippet) ?(?:(`[^`]+`)|([\\S]+))?(?: (\"[^\"]+\"))?(?: ([AMiwbm]*))?.*",
+      "begin": "^(snippet) ?(?:(`[^`]+`)|([\\S]+))?(?: (\"[^\"]+\"))?(?: ([AMiwbmh]*))?.*",
       "beginCaptures": {
         "1": {
           "name": "keyword.control"

--- a/syntaxes/hsnips.tmLanguage.yaml
+++ b/syntaxes/hsnips.tmLanguage.yaml
@@ -3,7 +3,7 @@ scopeName: "source.hsnips"
 name: comment
 patterns:
 -
-  begin: '^(snippet) ?(?:(`[^`]+`)|([\\S]+))?(?: (\"[^\"]+\"))?(?: ([AMiwbm]*))?.*'
+  begin: '^(snippet) ?(?:(`[^`]+`)|([\\S]+))?(?: (\"[^\"]+\"))?(?: ([AMiwbmh]*))?.*'
   beginCaptures:
     1:
       name: keyword.control


### PR DESCRIPTION
When adding the flag `h` to a non-regex snippet, this snippet will be hidden from the inline suggestions.
Useful to prevent unwanted behavior, when using automatic snippets and writing part of the trigger and to unclutter the inline suggestions.