### PR TITLE
[Bugfix] Nested math environment destroys context further down

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,6 +160,7 @@ export function activate(context: vscode.ExtensionContext) {
         text = text.replace(/```[\s\S]+?```/g, '')
         text = text.replace(/`[^`\n]+`/g, '')
         text = text.replace(/<!--[\s\S]+?-->/g, '')
+        text = text.replace(/(\$\$[^\$]+\$\$)|(\$[^\$]+?\$)/g, '') // avoid activating math env in cases such as \begin{equation} a = \text{$b$} \end{equation} //math env is activate after the equation
         const reg = /(\\begin\{gather\*\}[^\$]*?\\end\{gather\*\})|(\\begin\{gather\}[^\$]*?\\end\{gather\})|(\\begin\{align\*\}[^\$]*?\\end\{align\*\})|(\\begin\{align\}[^\$]*?\\end\{align\})|(\\begin\{equation\*\}[^\$]*?\\end\{equation\*\})|(\\begin\{equation\}[^\$]*?\\end\{equation\})|(\\\[[^\$]*?\\\])|(\\\([^\$]*?\\\))|(\$\$[^\$]+\$\$)|(\$[^\$]+?\$)/g
         text = text.replace(reg, '')
         if (text.indexOf('$') == -1 && text.indexOf('\\(') == -1 && text.indexOf('\\[') == -1 && text.indexOf('\\begin{equation}') == -1 && text.indexOf('\\begin{equation*}') == -1 && text.indexOf('\\begin{align}') == -1 && text.indexOf('\\begin{align*}') == -1 && text.indexOf('\\begin{gather}') == -1 && text.indexOf('\\begin{gather*}') == -1) {


### PR DESCRIPTION
Credit to @yu45020 from this [PR](https://github.com/OrangeX4/hsnips/pull/2)

- When having a math environment inside text environment inside a math environment, the parsing further down gets messed up. Take this example:
```
\begin{equation}
  a = \text{test $abc$}
\end{equation}
```
- As we have an inline math inside of the text, everything after the `\end{equation}`, will active math-only snippets, which is wrong. This ruins the entire experience in the rest of the file. 
- This did not resolve the fact that, the inner math environment isn't activated as such, and math snippets DO NOT work her. 

Any comments or testing is highly appreciated. 