### PR TITLE
feat: error message for  directory command.

### DIFF
--- a/src/openFileExplorer.ts
+++ b/src/openFileExplorer.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import * as os from 'os';
 import { spawn } from 'child_process';
 
@@ -6,7 +7,9 @@ import { spawn } from 'child_process';
  * @param {string} path The path string to be opened in the explorer
  * @param {Function} callback Callback function to which error is passed if some error occurs
  */
-export function openExplorer(path: string, callback: Function=(err: Error)=>{console.log(err)}) {
+export function openExplorer(path: string, callback: Function=(err: Error)=>{
+    vscode.window.showErrorMessage(err.message);
+}) {
     let platform: string = os.platform();
 
     let defaultPath = {
@@ -22,13 +25,16 @@ export function openExplorer(path: string, callback: Function=(err: Error)=>{con
     }
     
     if (!(platform == 'win32' || platform == 'darwin' || platform == 'linux')) {
-        return callback(new Error('Platform not supported'));
+        callback(new Error('Platform not supported'));
+        return;
     }
 
     path = path || defaultPath[platform];
     let p = spawn(commands[platform], [path]);
     p.on('error', (err) => {
         p.kill();
-        return callback(err);
+        callback(new Error(`Error: the term ${commands[platform]} is not recognized as the name of a cmdlet, function, script file, or executable program.
+            Please add ${commands[platform]} to your PATH environment variable.`));
+        return;
     });
 }


### PR DESCRIPTION
Gives an error message when there is no explorer command found in the system when the command openSnippetsDirectory is used.
I just copied the error message of powershell 7. I don't know what the best message is, but it should give some message.

Implements https://github.com/Oskar-Idland/hsnips/issues/12.