### PR TITLE
feat: use vscode's implementation to open directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ To use HyperSnips you create `.hsnips` files on a directory which depends on you
 
 - Windows: `%APPDATA%\Code\User\hsnips\(language).hsnips`
 - Mac: `$HOME/Library/Application Support/Code/User/hsnips/(language).hsnips`
-- Linux: `$HOME/.config/Code/User/hsnips/(language).hsnips`
+- Linux/ WSL: `$HOME/.config/Code/User/hsnips/(language).hsnips`
 
 Or alternatively, you can open this directory by running the command `HyperSnips: Open snippets directory`.
 
 Additionally, you can create an `all.hsnips` file for snippets that should be available on all languages.
+> [!NOTE]
+> The path in WSL is from the Linux instance not Windows.
 
 ### Snippets file
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,7 +92,27 @@ export function activate(context: vscode.ExtensionContext) {
     loadSnippets();
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('hsnips.openSnippetsDir', () => openExplorer(getSnippetDir()))
+        vscode.commands.registerCommand('hsnips.openSnippetsDir', () => {
+            // revealFileInOS opens the directory containing the file/dir, so to open the directory itself
+            // we use one of the snippet files to open the snippet directory and otherwise use on of the fallbacks.
+            const snippetDir = getSnippetDir();
+            if (!existsSync(snippetDir)) {
+                vscode.window.showErrorMessage(`The snippet directory does not exist: ${snippetDir}`);
+                return;
+            }
+            const files = readdirSync(snippetDir);
+            if (files.length == 0){
+                vscode.window.showWarningMessage(`The snippet directory is empty: ${snippetDir}, using fallback instead.`);
+                openExplorer(snippetDir, (err: Error) => {
+                    vscode.window.showWarningMessage("Failed to open the snippet directory, opening outside instead");
+                    const uri = vscode.Uri.file(snippetDir);
+                    vscode.commands.executeCommand('revealFileInOS', uri)
+                });
+            } else{
+                const uri = vscode.Uri.file(path.join(snippetDir, files[0]));
+                vscode.commands.executeCommand('revealFileInOS', uri)
+            }
+        })
     );
 
     context.subscriptions.push(

--- a/src/openFileExplorer.ts
+++ b/src/openFileExplorer.ts
@@ -12,25 +12,20 @@ export function openExplorer(path: string, callback: Function=(err: Error)=>{
 }) {
     let platform: string = os.platform();
 
-    let defaultPath: { [key: string]: string } = {
-        'win32': '.',
-        'darwin': '.',
-        'linux': '.'
-    }
-
     let commands: { [key: string]: string } = {
-        'win32': 'explorer',
+        // use start instead of explorer, since explorer isn't always in the PATH
+        'win32': 'start',
         'darwin': 'open',
         'linux': 'xdg-open'
     }
-    
     if (!(platform == 'win32' || platform == 'darwin' || platform == 'linux')) {
         callback(new Error('Platform not supported'));
         return;
-    }
-
-    path = path || defaultPath[platform];
-    let p = spawn(commands[platform], [path]);
+    };
+    path = path || '.';
+    // set shell to true such that start works in windows 
+    // and cwd to path instead of passing it on to avoid issues with spaces in path
+    let p = spawn(commands[platform], ["."], { shell: true, cwd: path });
     p.on('error', (err) => {
         p.kill();
         callback(new Error(`Error: the term ${commands[platform]} is not recognized as the name of a cmdlet, function, script file, or executable program.


### PR DESCRIPTION
Use vscode's implementation to open the file explorer instead of our own.
I tried to find the actual implementation but its obfuscated/abstracted behind a lot of stuff that I wasn't able to find it and this seems reasonable enough assuming they don't suddenly break it.

edit: I haven't setup commit verification yet on my fedora system.
edit2: fixed it.